### PR TITLE
update urls

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -33,7 +33,7 @@ theme: null
 # TODO this should not be hardcoded, but this is just a static marketing site so...
 nonce: not911
 
-url: "https://not911.nyc"
+url: "https://not911.us"
 plugins:
   - jekyll-sitemap
   # - jekyll-postcss

--- a/docs/_layouts/not911.html
+++ b/docs/_layouts/not911.html
@@ -9,7 +9,7 @@
     <meta name="theme-color" content="#A3EEAA" />
     <meta name="color-scheme" content="light">
     <title>{{ site.title }}</title>
-    <link rel="canonical" href="https://not911.nyc">
+    <link rel="canonical" href="https://not911.us">
     <link rel="icon" href="/assets/img/favicon.ico" type="image/ico">
     <link rel="icon" href="/assets/img/favicon-32x32.png" type="image/png">
     <link rel="manifest" href="/manifest.json">

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -43,7 +43,7 @@ layout: not911
             src="/assets/img/play-store.svg"
           />
         </a>
-        <a href="https://not911.nyc/app">
+        <a href="https://not911.us/app">
           <img
             alt="Or view as an installable web app"
             src="/assets/img/pwa.svg"


### PR DESCRIPTION
use .us instead of .nyc for canonical urls and PWA